### PR TITLE
chore: enable trusted publishing with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,20 +1,52 @@
-name: Release
-
-permissions:
-  pull-requests: write
-  contents: write
+name: Release-plz
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
-  release-plz:
-    uses: joshka/github-workflows/.github/workflows/rust-release-plz.yml@main
+  release:
+    name: Release-plz release
+    if: ${{ github.repository_owner == 'joshka' }}
+    runs-on: ubuntu-latest
+    environment: release
     permissions:
-      pull-requests: write
       contents: write
-    secrets:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      id-token: write
+    steps:
+      - &checkout
+        name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - &install-rust
+        name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release)
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release_pr:
+    name: Release-plz PR
+    if: ${{ github.repository_owner == 'joshka' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz (release-pr)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switch to trusted release-plz workflow using OIDC, fork guard, and GH token only.